### PR TITLE
Import of fortio.org/fortio/log replaced with fortio.org/log

### DIFF
--- a/ahdb.go
+++ b/ahdb.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/mooreatv/AHDBapp/lua2json"
 
-	"fortio.org/fortio/log"
+	"fortio.org/log"
 )
 
 // ScanEntry is 1 auction house scan result

--- a/lua2json/lua2json.go
+++ b/lua2json/lua2json.go
@@ -30,7 +30,7 @@ import (
 	"regexp"
 	"strings"
 
-	"fortio.org/fortio/log"
+	"fortio.org/log"
 )
 
 // RegsubInput is the input pattern+replacement string (or pattern)


### PR DESCRIPTION
Reason: "fortio.org/fortio/log" is deprecated: package has moved to [fortio.org/log].

Fixes #11 